### PR TITLE
Fixes rclone public acl and sets multipart limit

### DIFF
--- a/internal/toolConfig/aws_util.go
+++ b/internal/toolConfig/aws_util.go
@@ -19,6 +19,7 @@ const lumioS3serviceConfig = `[services %s]
 s3           = 
   endpoint_url = %s
   multipart_chunksize = %d
+  max_upload_parts = 1000
 `
 
 func deleteAwsEntry(path string, sectionNames []string) error {

--- a/internal/toolConfig/aws_util.go
+++ b/internal/toolConfig/aws_util.go
@@ -19,7 +19,6 @@ const lumioS3serviceConfig = `[services %s]
 s3           = 
   endpoint_url = %s
   multipart_chunksize = %d
-  max_upload_parts = 1000
 `
 
 func deleteAwsEntry(path string, sectionNames []string) error {

--- a/internal/toolConfig/rclone_util.go
+++ b/internal/toolConfig/rclone_util.go
@@ -72,13 +72,14 @@ func getRcloneSetting(a AuthInfo) map[string]map[string]string {
 	sharedRemoteSettings := map[string]string{
 		"type":              "s3",
 		"provider":          "Ceph",
+		"max_upload_parts":  "1000",
 		"env_auth":          "false",
 		"project_id":        fmt.Sprintf("%d", a.ProjectId),
 		"access_key_id":     a.s3AccessKey,
 		"secret_access_key": a.s3SecretKey,
 		"endpoint":          a.Url}
 	rcloneSettings[privateRemoteName] = util.MergeMaps(map[string]string{"acl": "private"}, sharedRemoteSettings)
-	rcloneSettings[publicRemoteName] = util.MergeMaps(map[string]string{"acl": "public"}, sharedRemoteSettings)
+	rcloneSettings[publicRemoteName] = util.MergeMaps(map[string]string{"acl": "public-read"}, sharedRemoteSettings)
 
 	return rcloneSettings
 }


### PR DESCRIPTION
An incorrect ACL value was used when configuring rclone, should be `public-read` instead of `read`
LUMI-O only supports 1000 parts as opposed to aws s3  10,000 